### PR TITLE
Patch: Fixed bug where re-assignment via the operator[] would cause a…

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -6,7 +6,8 @@ every change, see the Git log.
 
 Latest
 ------
-* tbd
+* Patch: Fixed bug where re-assignment via the ``operator[]`` would cause a memory
+  leak.
 
 10.0.1
 ------

--- a/src/bourne/json.cpp
+++ b/src/bourne/json.cpp
@@ -92,6 +92,7 @@ json& json::operator=(const json& other)
     if (this == &other)
         return *this;
 
+    clear();
     switch (other.m_type)
     {
     case class_type::object:

--- a/test/src/test_json.cpp
+++ b/test/src/test_json.cpp
@@ -302,3 +302,13 @@ TEST(test_json, test_unicode_dump)
         EXPECT_EQ(expected, object.dump_min());
     }
 }
+
+TEST(test_json, nested_assignment_cause_memory_leak)
+{
+    bourne::json object1;
+    bourne::json object2;
+    object1["key1"] = bourne::json::object();
+    object2["key2"] = bourne::json::object();
+    std::cout << "now" << std::endl;
+    object1["key1"] = object2["key2"];
+}


### PR DESCRIPTION
… memory leak.